### PR TITLE
Add message_separator option

### DIFF
--- a/lib/Mojo/Log/Role/AttachLogger.pm
+++ b/lib/Mojo/Log/Role/AttachLogger.pm
@@ -15,28 +15,29 @@ requires 'on';
 sub attach_logger {
   my ($self, $logger, $opt) = @_;
   Carp::croak 'No logger passed' unless defined $logger;
-  my ($category, $prepend);
+  my ($category, $prepend, $separator);
   if (ref $opt) {
-    ($category, $prepend) = @$opt{'category','prepend_level'};
+    ($category, $prepend, $separator) = @$opt{qw[ category prepend_level message_separator ]};
   } else {
     $category = $opt;
   }
   $category //= 'Mojo::Log';
   $prepend //= 1;
-  
+  $separator //= "\n";
+
   my $do_log;
   if (Scalar::Util::blessed($logger)) {
     if ($logger->isa('Log::Any::Proxy')) {
       $do_log = sub {
         my ($self, $level, @msg) = @_;
-        my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+        my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
         $msg = "[$level] $msg" if $prepend;
         $logger->$level($msg);
       };
     } elsif ($logger->isa('Log::Dispatch')) {
       $do_log = sub {
         my ($self, $level, @msg) = @_;
-        my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+        my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
         $msg = "[$level] $msg" if $prepend;
         $level = 'critical' if $level eq 'fatal';
         $logger->log(level => $level, message => $msg);
@@ -44,7 +45,7 @@ sub attach_logger {
     } elsif ($logger->isa('Log::Dispatchouli') or $logger->isa('Log::Dispatchouli::Proxy')) {
       $do_log = sub {
         my ($self, $level, @msg) = @_;
-        my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+        my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
         $msg = "[$level] $msg" if $prepend;
         return $logger->log_debug($msg) if $level eq 'debug';
         # hacky but we don't want to use log_fatal because it throws an
@@ -66,7 +67,7 @@ sub attach_logger {
     $logger = Log::Any->get_logger(category => $category);
     $do_log = sub {
       my ($self, $level, @msg) = @_;
-      my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+      my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
       $msg = "[$level] $msg" if $prepend;
       $logger->$level($msg);
     };
@@ -75,7 +76,7 @@ sub attach_logger {
     $logger = Log::Log4perl->get_logger($category);
     $do_log = sub {
       my ($self, $level, @msg) = @_;
-      my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+      my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
       $msg = "[$level] $msg" if $prepend;
       $logger->$level($msg);
     };
@@ -86,7 +87,7 @@ sub attach_logger {
     "$logger"->import::into(ref($self), values %functions);
     $do_log = sub {
       my ($self, $level, @msg) = @_;
-      my $msg = @msg > 1 ? join("\n", @msg) : $msg[0];
+      my $msg = @msg > 1 ? join($separator, @msg) : $msg[0];
       $msg = "[$level] $msg" if $prepend;
       $self->can($functions{$level})->($msg);
     };
@@ -111,7 +112,7 @@ Mojo::Log::Role::AttachLogger - Use other loggers for Mojo::Log
   my $log = Mojo::Log->with_roles('+AttachLogger')->new->unsubscribe('message');
   
   # Log::Any
-  use Log::Any::Adapter {category => 'Mojo::Log'}, 'Syslog';
+  use Log::Any::Adapter {category => 'Mojo::Log', message_separator => ' '}, 'Syslog';
   $log->attach_logger('Log::Any', 'Some::Category');
   
   # Log::Contextual
@@ -230,6 +231,10 @@ Category name (defaults to Mojo::Log).
 
 Prepend the log level to messages in the form C<[$level]> (default for
 non-L<Mojo::Log> loggers). Set false to disable.
+
+=item message_separator
+
+String to separate multiple messages. Defaults to newline.
 
 =back
 

--- a/lib/Mojolicious/Plugin/Log/Any.pm
+++ b/lib/Mojolicious/Plugin/Log/Any.pm
@@ -30,7 +30,7 @@ Mojolicious::Plugin::Log::Any - Use other loggers in a Mojolicious application
     my $self = shift;
     
     # Log::Any (default)
-    use Log::Any::Adapter {category => 'MyApp'}, 'Syslog';
+    use Log::Any::Adapter {category => 'MyApp', message_separator => ' '}, 'Syslog';
     $self->plugin('Log::Any');
     
     # Log::Contextual
@@ -107,6 +107,10 @@ Passed through to L<Mojo::Log::Role::AttachLogger/"attach_logger">. Defaults to
 the application name.
 
 =item prepend_level
+
+Passed through to L<Mojo::Log::Role::AttachLogger/"attach_logger">.
+
+=item message_separator
 
 Passed through to L<Mojo::Log::Role::AttachLogger/"attach_logger">.
 

--- a/t/log_any.t
+++ b/t/log_any.t
@@ -15,13 +15,13 @@ use Test::More;
 my @levels = qw(debug info warn error fatal);
 
 my $log = Mojo::Log->with_roles('Mojo::Log::Role::AttachLogger')->new
-  ->unsubscribe('message')->attach_logger('Log::Any', {category => 'Test::Category', prepend_level => 0});
+  ->unsubscribe('message')->attach_logger('Log::Any', {category => 'Test::Category', prepend_level => 0, message_separator => ' '});
 
 my $log_any = Log::Any->get_logger(category => 'Test::Category');
 foreach my $level (@levels) {
   $log_any->clear;
   $log->$level('test', 'message');
-  $log_any->category_contains_ok('Test::Category', qr/test\nmessage$/m, "$level log message");
+  $log_any->category_contains_ok('Test::Category', qr/test message$/m, "$level log message");
   $log_any->clear;
   $log->$level(My::Exception->new);
   $log_any->category_does_not_contain_ok('Test::Category', qr/^Mojo::Log::Role::AttachLogger$/m, "$level log object not stringified");


### PR DESCRIPTION
This adds a message_separator option to override the newlines used to separate messages. For example, a space may be more appropriate for logging to Syslog. This fixes #4.